### PR TITLE
Remove numeric labels from window tiles

### DIFF
--- a/script.js
+++ b/script.js
@@ -45,14 +45,10 @@ function createWindowElement(id) {
     windowEl.classList.add(`color-${(id % 8) + 1}`);
     windowEl.dataset.windowId = String(id);
 
-    const label = document.createElement('span');
-    label.className = 'window-label';
-    label.textContent = id;
-
     const closeButton = document.createElement('button');
     closeButton.type = 'button';
     closeButton.className = 'window-close';
-    closeButton.setAttribute('aria-label', `Close window ${id}`);
+    closeButton.setAttribute('aria-label', 'Close window');
     closeButton.title = 'Close window';
     closeButton.innerHTML = `
         <svg viewBox="0 0 10 10" aria-hidden="true" focusable="false">
@@ -65,7 +61,7 @@ function createWindowElement(id) {
         closeWindow(id);
     });
 
-    windowEl.append(label, closeButton);
+    windowEl.append(closeButton);
     workspace.appendChild(windowEl);
 
     return windowEl;

--- a/script.js
+++ b/script.js
@@ -48,7 +48,7 @@ function createWindowElement(id) {
     const closeButton = document.createElement('button');
     closeButton.type = 'button';
     closeButton.className = 'window-close';
-    closeButton.setAttribute('aria-label', 'Close window');
+    closeButton.setAttribute('aria-label', `Close window ${id}`);
     closeButton.title = 'Close window';
     closeButton.innerHTML = `
         <svg viewBox="0 0 10 10" aria-hidden="true" focusable="false">


### PR DESCRIPTION
## Summary
- stop rendering numeric labels on generated windows
- update close button aria label now that windows are unnumbered

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_b_68f85bda73d0832f9baaf6bcd213580e